### PR TITLE
fix: use shadcn UI buttons for sign-in and sign-up

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   SignedOut,
   UserButton,
 } from "@clerk/nextjs";
+import { Button } from "@/components/ui/button";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -40,8 +41,12 @@ export default function RootLayout({
             <h1 className="text-xl font-bold">Lifting Diary</h1>
             <div className="flex gap-4">
               <SignedOut>
-                <SignInButton mode="modal" />
-                <SignUpButton mode="modal" />
+                <SignInButton mode="modal">
+                  <Button variant="outline">Sign In</Button>
+                </SignInButton>
+                <SignUpButton mode="modal">
+                  <Button>Sign Up</Button>
+                </SignUpButton>
               </SignedOut>
               <SignedIn>
                 <UserButton />


### PR DESCRIPTION
Replace default Clerk button rendering with shadcn UI Button components:
- Sign In button uses 'outline' variant
- Sign Up button uses default primary variant

Resolves #6